### PR TITLE
Fix the non correct description of the `is24111()` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Help to distinguish between smartphone model.
 | boolean  | ```is22111()``` <br> Whether model is Phone (2)       |
 | boolean  | ```is23111()``` <br> Whether model is Phone (2a)      |
 | boolean  | ```is23113()``` <br> Whether model is Phone (2a) Plus |
-| boolean  | ```is24111()``` <br> Whether model is Phone (3a) Pro and Phone (3a) Pro |
+| boolean  | ```is24111()``` <br> Whether model is Phone (3a) or Phone (3a) Pro |
 ## Glyph
 How the Glyph Interface is indexed
 ### Nothing Phone (1)


### PR DESCRIPTION
The original text specifies that it checks for the Pro only. But the function checks if the model string of the device *contains* `A059` which therefore also supports the pro's model string of `A059P`.

I don't have a 3a and 3a Pro to test this but from what I can see from the decompiled code this should be the right and originally intended description.

***

Mentioning this here because I doubt that the issues will be read any time soon - this was found by @Fr4nKB, all credits of the below described findings go to him:
> **The mapping of the glyphs to the A_#, B_# and C_# constants might be wrong:**
> ![image](https://github.com/user-attachments/assets/d10a9f99-1adb-41bc-b843-83c5739f77dd)
>There seems to be a deviation between the documentation and how many zones each of the A_#, B_# and C_# constants have.  
A_# should have A_1 to A_20 constants according to the documentation - the other constants are therefore also not aligned with the doc.